### PR TITLE
Remove invalid "run" argument to Python

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -12,7 +12,6 @@ ROOT = pathlib.Path(__file__).parent.resolve().as_posix()
 def tests(context):
     cmd = [
         "python",
-        "run",
         "-m",
         "robot",
         f"--variable=root:{ROOT}",


### PR DESCRIPTION
Otherwise poetry run tests will result in: python: can't open file 'run': [Errno 2] No such file or directory